### PR TITLE
Build docker image on github and push the image to githubs docker registry

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -18,8 +18,6 @@ jobs:
       - name: Build Docker container and push it to GitHub Packages
         uses: lojoh/build-and-push-multi-platform-docker-images-action@2.0
         with:
-          docker-args: |
-            ReleaseVersion=${{ steps.version.outputs.version }}
           docker-context: .
           docker-file: Dockerfile
           docker-registry: ghcr.io/fehu

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -22,7 +22,7 @@ jobs:
           docker-file: Dockerfile
           docker-registry: ghcr.io/fehu
           github-token: ${{ secrets.PAT }}
-          image-name: fehu-bitcoind
+          image-name: docker-bitcoind
           tag: ${{ steps.version.outputs.version }}
           platform: linux/amd64
 

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -25,7 +25,7 @@ jobs:
           docker-context: .
           docker-file: Dockerfile
           docker-registry: ghcr.io/fehu
-          github-token: ${{ secrets.PAT }}
+          github-token: ${{ secrets.FEHU_TOKEN }}
           image-name: docker-bitcoind
           tag: ${{ env.tag }}
           platform: linux/amd64

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,35 @@
+name: Build docker image
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-application:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: lojoh/lojoh-github-actions-private/.github/actions/generate-semantic-version-number@2.1
+        id: version
+
+      - name: Use version number
+        run: echo ${{ steps.version.outputs.version }}
+
+      - name: Build Docker container and push it to GitHub Packages
+        uses: lojoh/build-and-push-multi-platform-docker-images-action@2.0
+        with:
+          docker-args: |
+            ReleaseVersion=${{ steps.version.outputs.version }}
+          docker-context: .
+          docker-file: Dockerfile
+          docker-registry: ghcr.io/fehu
+          github-token: ${{ secrets.PAT }}
+          image-name: fehu-bitcoind
+          tag: ${{ steps.version.outputs.version }}
+          platform: linux/amd64
+
+      - name: Create git tag and push if on main branch
+        uses: lojoh/lojoh-github-actions-private/.github/actions/git-tag-and-push@2.1
+        if: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+        with:
+          tag: ${{ steps.version.outputs.version }}

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -3,17 +3,21 @@ name: Build docker image
 on:
   workflow_dispatch:
 
+env:
+  MAJOR: 26
+  MINOR: 0
+
 jobs:
   build-application:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - uses: lojoh/lojoh-github-actions-private/.github/actions/generate-semantic-version-number@2.1
-        id: version
+      - name: Store new version number as env
+        run: echo "tag=$MAJOR.$MINOR.${{ github.run_number }}" >> $GITHUB_ENV
 
       - name: Use version number
-        run: echo ${{ steps.version.outputs.version }}
+        run: echo ${{ env.tag }}
 
       - name: Build Docker container and push it to GitHub Packages
         uses: lojoh/build-and-push-multi-platform-docker-images-action@2.0
@@ -23,11 +27,14 @@ jobs:
           docker-registry: ghcr.io/fehu
           github-token: ${{ secrets.PAT }}
           image-name: docker-bitcoind
-          tag: ${{ steps.version.outputs.version }}
+          tag: ${{ env.tag }}
           platform: linux/amd64
 
-      - name: Create git tag and push if on main branch
-        uses: lojoh/lojoh-github-actions-private/.github/actions/git-tag-and-push@2.1
-        if: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
-        with:
-          tag: ${{ steps.version.outputs.version }}
+      - name: Create git tag
+        shell: bash
+        run: |
+          git tag ${{ env.tag }}
+
+      - name: Push git tag
+        shell: bash
+        run: git push origin ${{ env.tag }}


### PR DESCRIPTION
- Builds a docker image from the Dockerfile and pushes it to githubs docker registry
- The name of the image will be fehu-bitcoind:major.minor.build. Any suggestions for better naming?
- This makes it possible for users to start a container like this: `docker run ghcr.io/fehu/fehu-bitcoind:26.0.0`
- I am not sure whether fehu as an organization has the permissions to access my private workflows. If not I have to make them public or copy/paste the code to this organization. Can't test this before it is on the main branch or if it do it in some testrepo or something.
- This workflow will also tag the latest commit with the same tag as the image. For instance, let's imagine it creates the image `fehu-bitcoind:1.2.3`, it will also create a git tag called `1.2.3` and push it to the repo.